### PR TITLE
amana, inc.の退職日を更新

### DIFF
--- a/apps/yet/content/careers.json
+++ b/apps/yet/content/careers.json
@@ -109,6 +109,6 @@
     "stacks": [],
     "roles": ["Manager"],
     "joinedAt": "2024-01-22",
-    "leavedAt": null
+    "leavedAt": "2026-02-28"
   }
 ]


### PR DESCRIPTION
## Summary
- amana, inc.の`leavedAt`を`null`（現職）から`2026-02-28`（退職済み）に更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)