### PR TITLE
Careersセクションの表示順を降順（新しい順）に変更

### DIFF
--- a/apps/yet/libs/content.ts
+++ b/apps/yet/libs/content.ts
@@ -12,5 +12,7 @@ export function getProjects(): Project[] {
 }
 
 export function getCareers(): Career[] {
-  return careersData as Career[];
+  return (careersData as Career[]).toSorted(
+    (a, b) => new Date(b.joinedAt).getTime() - new Date(a.joinedAt).getTime(),
+  );
 }


### PR DESCRIPTION
## Summary
- ポートフォリオ（yet.unresolved.xyz）のCareersセクションを `joinedAt` の降順（新しい職歴が上）でソートするよう変更
- JSONファイルの順序には依存せず、コード側で `toSorted()` によりソートを保証

## Test plan
- [ ] `pnpm build` が成功すること
- [ ] `pnpm lint` がエラーなく通ること
- [ ] Careersセクションの表示順が新しい職歴から順に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)