### PR TITLE
Projectコンポーネントのスマホ向けレスポンシブ対応

### DIFF
--- a/apps/yet/components/projects/Project.tsx
+++ b/apps/yet/components/projects/Project.tsx
@@ -10,7 +10,7 @@ interface ProjectProps {
 export const Project: FC<ProjectProps> = ({ project }) => {
   return (
     <div className={project.closed ? 'opacity-60' : ''}>
-      <div className="flex items-start gap-4">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
         {project.image && (
           <Image
             src={project.image}
@@ -21,7 +21,7 @@ export const Project: FC<ProjectProps> = ({ project }) => {
           />
         )}
         <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <h3 className="font-bold text-2xl">
               {project.title}
               {project.closed && (


### PR DESCRIPTION
## Summary
- スマホでProjectの画像アイコンとテキストが横並びではみ出す問題を修正
- スマホでは画像を上・テキストを下の縦積み(`flex-col`)にし、sm以上で従来通り横並び(`sm:flex-row`)に切り替え
- タイトル行に`flex-wrap`を追加し、タイトルが長い場合もリンクボタンが隠れないように対応

## Test plan
- [x] `pnpm build --filter=yet` ビルド成功
- [x] `pnpm lint` エラーなし
- [ ] スマホ幅で画像が上・テキストが下に縦積みされることを確認
- [ ] sm以上で従来通り画像左・テキスト右の横並びになることを確認
- [ ] タイトルが長いProjectでもリンクボタンが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)