### PR TITLE
Careerコンポーネントの日付・ロール行スマホ向けレスポンシブ対応

### DIFF
--- a/apps/yet/components/careers/Career.tsx
+++ b/apps/yet/components/careers/Career.tsx
@@ -15,14 +15,14 @@ export const Career: FC<CareerProps> = ({ career }) => {
       </div>
       <div>
         <h3 className="font-medium text-xl">{career.companyName}</h3>
-        <p className="mt-1 flex gap-2 text-sm opacity-60">
+        <p className="mt-1 flex flex-col text-sm opacity-60 sm:flex-row sm:gap-2">
           <span>
             {[
               career.joinedAt.slice(0, 7),
               career.leavedAt ? career.leavedAt.slice(0, 7) : 'Present',
             ].join(' - ')}
           </span>
-          <span className="opacity-60">・</span>
+          <span className="hidden opacity-60 sm:inline">・</span>
           <span>{career.roles.join(' / ')}</span>
         </p>
         {career.stacks.length > 0 && (


### PR DESCRIPTION
## Summary
- Careerコンポーネントの日付・ロール行がスマホ幅で折り返しが崩れる問題を修正
- スマホでは日付とロールを縦積み（`flex-col`）にし、sm以上で横並び（`sm:flex-row`）に切り替え
- セパレータ「・」をスマホでは非表示（`hidden sm:inline`）に変更

## Test plan
- [ ] `pnpm build --filter=yet` でビルド成功を確認
- [ ] `pnpm lint` でエラーなしを確認
- [ ] スマホ幅（< 640px）で日付とロールが縦積みになることを確認
- [ ] sm以上の幅で従来通り横並び＋セパレータ表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)