### PR TITLE
yet のヘッダーにブランドマークを導入

### DIFF
--- a/apps/yet/app/layout.tsx
+++ b/apps/yet/app/layout.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from 'next';
+import Image from 'next/image';
+import Link from 'next/link';
 import Script from 'next/script';
 import '@styles/global.css';
+import { Container } from '@components';
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://yet.unresolved.xyz'),
@@ -24,6 +27,22 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="text-xl leading-normal">
+        <header className="py-4">
+          <Container>
+            <Link
+              href="/"
+              className="flex items-center gap-4 font-semibold text-xl tracking-widest hover:underline"
+            >
+              <Image
+                src="/images/logo.svg"
+                alt="yet.unresolved.xyz"
+                width={50}
+                height={50}
+              />
+              yet.unresolved.xyz
+            </Link>
+          </Container>
+        </header>
         <main>
           <Script
             src="https://www.googletagmanager.com/gtag/js?id=G-GQEKXQNCLH"

--- a/apps/yet/public/images/logo.svg
+++ b/apps/yet/public/images/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <path d="M 59.35 19.4 A 32 32 0 1 0 80.6 40.65" fill="none" stroke="#333333" stroke-width="13" stroke-linecap="round"/>
+  <circle cx="72.6" cy="27.4" r="6.5" fill="#ffffff"/>
+</svg>


### PR DESCRIPTION
## Summary
- #700 で favicon / OGP は blog・yet 両アプリに導入済みだったが、ページ上に見えるブランドマークは blog のヘッダーロゴのみだったため、yet にも blog と同じ構成のヘッダー（マーク 50px + ドメイン表記 `yet.unresolved.xyz`）を追加
- `apps/yet/public/images/logo.svg` を新規作成。yet の色の文法（インク `#333` × 白ドット）に従い、ページ背景が既にブランド黄 `#FDCE12` のため favicon のような黄タイルは持たせずマーク単体
- ヘッダーの文字色は yet の基調色 `#333` に乗せるため、blog にある `text-black` は付けていない

## Test plan
- [x] `pnpm --filter yet build` が成功
- [x] `pnpm lint`（Biome + markdownlint）が成功
- [x] dev サーバーを起動しスクリーンショットでヘッダー表示を確認（黄地にインクの欠けた円 + 白ドット）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * サイト全体にヘッダーを追加しました。
  * ロゴとサイト名を表示し、クリックするとホームへ移動できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->