### PR TITLE
js-yaml 3.x を 3.15.0 以上に固定し audit の high を解消

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
       "lefthook"
     ],
     "overrides": {
-      "axios": "1.13.5"
+      "axios": "1.13.5",
+      "js-yaml@3": "^3.15.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   axios: 1.13.5
+  js-yaml@3: ^3.15.0
 
 importers:
 
@@ -971,8 +972,8 @@ packages:
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
   js-yaml@5.2.1:
@@ -2214,7 +2215,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -2343,7 +2344,7 @@ snapshots:
 
   js-tokens@10.0.0: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1


### PR DESCRIPTION
## Summary
- GHSA-52cp-r559-cp3m（js-yaml の YAML merge-key による quadratic CPU 消費、severity: high）が公開され、blog の gray-matter 経由の js-yaml 3.14.x が検出されて CI の Security audit が全 PR で落ちる状態になっていた（#702 で顕在化）
- js-yaml 3.15.0（3.x 系へのバックポート修正）が公開済みのため、pnpm overrides に `"js-yaml@3": "^3.15.0"` を追加して 3.x 系のみ引き上げ。4.x / 5.x 系には影響しない

## Test plan
- [x] `pnpm audit --audit-level=high --prod` がローカルで exit 0（high 解消、moderate も 2→1 に減少）
- [x] `pnpm --filter blog build` 成功（gray-matter の frontmatter パースは js-yaml 3.15.0 で互換）
- [x] `pnpm test` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)