### PR TITLE
blog / yet を Custom Domain に接続する

### DIFF
--- a/apps/blog/wrangler.jsonc
+++ b/apps/blog/wrangler.jsonc
@@ -10,5 +10,12 @@
     // 静的アセットに一致しないリクエストには out/404.html を 404 として返す。
     // 既定値のままだと素の 404 になり、生成済みの 404 ページが使われない。
     "not_found_handling": "404-page"
-  }
+  },
+  // Custom Domain は DNS レコードと証明書を Cloudflare 側が自動で用意する。
+  // 対象ホスト名に既存の CNAME があると作成に失敗するため、Vercel を向いていた
+  // レコードは事前に削除してある。
+  "routes": [{ "pattern": "blog.unresolved.xyz", "custom_domain": true }],
+  // workers.dev のURLは当面残す。カスタムドメイン側で問題が起きたときに、
+  // Worker 自体の問題か DNS / 証明書の問題かを切り分けられるようにするため。
+  "workers_dev": true
 }

--- a/apps/yet/wrangler.jsonc
+++ b/apps/yet/wrangler.jsonc
@@ -10,5 +10,12 @@
     // 静的アセットに一致しないリクエストには out/404.html を 404 として返す。
     // 既定値のままだと素の 404 になり、生成済みの 404 ページが使われない。
     "not_found_handling": "404-page"
-  }
+  },
+  // Custom Domain は DNS レコードと証明書を Cloudflare 側が自動で用意する。
+  // 対象ホスト名に既存の CNAME があると作成に失敗するため、Vercel を向いていた
+  // レコードは事前に削除してある。
+  "routes": [{ "pattern": "yet.unresolved.xyz", "custom_domain": true }],
+  // workers.dev のURLは当面残す。カスタムドメイン側で問題が起きたときに、
+  // Worker 自体の問題か DNS / 証明書の問題かを切り分けられるようにするため。
+  "workers_dev": true
 }


### PR DESCRIPTION
## Summary

`blog.unresolved.xyz` / `yet.unresolved.xyz` を Cloudflare Workers の Custom Domain に接続した。これで Vercel を経由しなくなる。

- 両 `wrangler.jsonc` に `routes` + `custom_domain: true` を追加
- `workers_dev` は当面 `true` のまま残す（切り分け用）

## 経緯

Custom Domain は対象ホスト名に既存の CNAME があると作成に失敗する。Vercel を向いていた CNAME を先に削除する必要があり、その間はサイトが落ちるため、**復旧を優先してローカルの `wrangler deploy` で先に適用済み**。

Custom Domain の作成は冪等なので、このPRがマージされて Actions からデプロイされても同じ状態が保たれる。**このPRは、既に適用済みのインフラ設定をコードに反映して整合させるためのもの。**

## 稼働確認済み

DNS のネガティブキャッシュを迂回して実サービスを確認した。

| | blog | yet |
|---|---|---|
| トップ | 200 | 200 |
| 記事ページ | 200 | — |
| 画像 | 200 | 200 |
| 存在しないパス | 404 + 404ページ | 404 + 404ページ |

- `server: cloudflare` / `cf-ray: ...-NRT`
- 証明書は既存の Universal SSL（`CN=unresolved.xyz`, Google Trust Services）がそのまま有効で、**発行待ちによるダウンタイムは発生しなかった**

## Test plan

- [ ] マージ後、Deploy ワークフローが成功する
- [ ] `blog.unresolved.xyz` / `yet.unresolved.xyz` が引き続き 200 を返す

## 残作業

- [ ] Vercel の blog / yet プロジェクトを削除する
- [ ] Vercel Pro を解約する
- [ ] 落ち着いたら `workers_dev` を `false` にする

🤖 Generated with [Claude Code](https://claude.com/claude-code)