### PR TITLE
Deploy ワークフローの GITHUB_TOKEN 権限を最小化する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,11 @@ concurrency:
   group: deploy
   cancel-in-progress: false
 
+# このワークフローはリポジトリの読み取りしか行わない（デプロイ先は Cloudflare で、
+# 認証は CLOUDFLARE_API_TOKEN が担う）。GITHUB_TOKEN の権限は最小限に絞る。
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Deploy to Cloudflare Workers
@@ -20,6 +25,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # git への書き込みは行わないため、認証情報を .git/config に残さない。
+          persist-credentials: false
 
       - name: Setup pnpm environment
         uses: pnpm/action-setup@v6
@@ -69,6 +77,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # コミットメッセージを git log で読むだけなので認証情報は不要。
+          persist-credentials: false
 
       - name: Build Slack payload
         # コミットメッセージに引用符やバックスラッシュが含まれても payload が壊れないよう、


### PR DESCRIPTION
## Summary

#706 で CodeRabbit から受けた指摘への対応。

Deploy ワークフローはリポジトリの読み取りしか行わず、デプロイ先の認証は `CLOUDFLARE_API_TOKEN` が担っている。またこのリポジトリは public なので、既定の広い権限のまま `GITHUB_TOKEN` を持ち回る必要がない。

- `permissions` に `contents: read` を明示
- 両ジョブの `actions/checkout` に `persist-credentials: false` を設定し、認証情報が `.git/config` に残らないようにする

`deployments: write` は付けていない。`cloudflare/wrangler-action` は GitHub Deployment を作らないため不要。

## Test plan

- [ ] マージ後、Deploy ワークフローが引き続き成功する（checkout / build / deploy / Slack 通知すべて）

🤖 Generated with [Claude Code](https://claude.com/claude-code)