### PR TITLE
Cloudflare Workers 移行後の実態に合わせてドキュメントを更新する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Turborepo monorepo containing two Next.js websites:
 - **apps/blog** — Blog at blog.unresolved.xyz (Next.js App Router, local Markdown content, Tailwind CSS)
-- **apps/yet** — Portfolio at yet.unresolved.xyz (Next.js App Router, static JSON content, Tailwind CSS)
+- **apps/yet** — Portfolio at yet.unresolved.xyz (Next.js App Router, static TypeScript content, Tailwind CSS)
 - **packages/tsconfig** — Shared TypeScript configurations
 
 ## Common Commands
@@ -50,7 +50,7 @@ Blog dev server runs on port 3001, Yet on port 3000.
 
 ### Yet App (`apps/yet`)
 - Next.js App Router (single page portfolio)
-- Content managed via static JSON files in `content/` directory
+- Content managed via static TypeScript modules in `content/` (`profile.ts`, `projects.ts`, `careers.ts`)
 - Type definitions in `types/content.ts`
 - Tailwind CSS for styling
 
@@ -68,4 +68,12 @@ Both apps use TypeScript path aliases:
 
 ## CI Pipeline
 
-GitHub Actions runs on push to main and PRs: build → syncpack lint → biome lint → test.
+`.github/workflows/ci.yml` runs on push to main and PRs: build → syncpack lint → biome lint → test → security audit.
+
+The security audit runs `pnpm audit --audit-level=high --prod`. Because transitive dependencies pinned by Next.js can trip it without any direct dependency being at fault, such advisories are resolved with `pnpm.overrides` in the root `package.json`.
+
+## Deployment
+
+`.github/workflows/deploy.yml` runs on push to main and deploys both apps to Cloudflare Workers with `wrangler`, then notifies Slack.
+
+Both apps use `output: 'export'` and are served as static asset Workers, configured per app in `wrangler.jsonc` with custom domains. Deploys require the `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` repository secrets; the Slack notification requires `SLACK_WEBHOOK_URL`.

--- a/apps/blog/README.md
+++ b/apps/blog/README.md
@@ -1,30 +1,47 @@
+# blog
+
+Tech blog published at [blog.unresolved.xyz](https://blog.unresolved.xyz/).
+
+Built with Next.js (App Router) and Tailwind CSS. Posts are local Markdown files, so there is no CMS or database to configure.
+
 ## Getting Started
 
-First, run the development server:
+Install dependencies from the repository root, then start the development server:
 
 ```bash
-yarn dev
+pnpm i
+pnpm dev --filter blog
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3001](http://localhost:3001) with your browser to see the result. Running `pnpm dev` from the root starts every app in the monorepo instead.
 
-You can start editing the page by modifying `pages/index.js`. The page auto-updates as you edit the file.
+## Content
 
-[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.js`.
+Posts live in `content/posts/` as Markdown files with gray-matter frontmatter. Adding a file is enough to publish a post — routes are generated from the filename via the `[slug]` dynamic route, and Markdown is rendered through a remark/rehype pipeline with syntax highlighting.
 
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
+## Build
+
+```bash
+pnpm build --filter blog
+```
+
+The app is configured with `output: 'export'`, so the build emits a fully static site to `out/`.
+
+To preview that output the same way it is served in production, run:
+
+```bash
+pnpm start --filter blog
+```
+
+This runs `wrangler dev` against the built assets rather than the Next.js development server.
+
+## Deployment
+
+Deployment is handled by Cloudflare Workers as a static asset Worker, configured in `wrangler.jsonc` and served at the `blog.unresolved.xyz` custom domain.
+
+Pushing to `main` triggers the `Deploy` GitHub Actions workflow, which builds every app and deploys them with `wrangler`. There is no manual deploy step in the normal flow.
 
 ## Learn More
 
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn/foundations/about-nextjs) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_source=github.com&utm_medium=referral&utm_campaign=turborepo-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+- [Next.js Documentation](https://nextjs.org/docs)
+- [Cloudflare Workers static assets](https://developers.cloudflare.com/workers/static-assets/)

--- a/apps/yet/README.md
+++ b/apps/yet/README.md
@@ -1,30 +1,53 @@
+# yet
+
+Portfolio site published at [yet.unresolved.xyz](https://yet.unresolved.xyz/).
+
+A single page built with Next.js (App Router) and Tailwind CSS. All content is checked into the repository, so there is no CMS or database to configure.
+
 ## Getting Started
 
-First, run the development server:
+Install dependencies from the repository root, then start the development server:
 
 ```bash
-yarn dev
+pnpm i
+pnpm dev --filter yet
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result. Running `pnpm dev` from the root starts every app in the monorepo instead.
 
-You can start editing the page by modifying `pages/index.js`. The page auto-updates as you edit the file.
+## Content
 
-[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.js`.
+The page is driven by the static content modules in `content/`:
 
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
+- `profile.ts` — profile and introduction
+- `projects.ts` — project list
+- `careers.ts` — work history
+
+Their shapes are defined in `types/content.ts`. Editing these files is all that is needed to update the site.
+
+## Build
+
+```bash
+pnpm build --filter yet
+```
+
+The app is configured with `output: 'export'`, so the build emits a fully static site to `out/`.
+
+To preview that output the same way it is served in production, run:
+
+```bash
+pnpm start --filter yet
+```
+
+This runs `wrangler dev` against the built assets rather than the Next.js development server.
+
+## Deployment
+
+Deployment is handled by Cloudflare Workers as a static asset Worker, configured in `wrangler.jsonc` and served at the `yet.unresolved.xyz` custom domain.
+
+Pushing to `main` triggers the `Deploy` GitHub Actions workflow, which builds every app and deploys them with `wrangler`. There is no manual deploy step in the normal flow.
 
 ## Learn More
 
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn/foundations/about-nextjs) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_source=github.com&utm_medium=referral&utm_campaign=turborepo-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+- [Next.js Documentation](https://nextjs.org/docs)
+- [Cloudflare Workers static assets](https://developers.cloudflare.com/workers/static-assets/)

--- a/apps/yet/content/projects.ts
+++ b/apps/yet/content/projects.ts
@@ -35,7 +35,7 @@ export const projects: Project[] = [
     image: '/images/projects/yet-unresolved-xyz.png',
     title: 'yet.unresolved.xyz',
     description: 'This portfolio site.',
-    stacks: ['Next.js', 'Vercel', 'Turborepo', 'Tailwind CSS'],
+    stacks: ['Next.js', 'Cloudflare Workers', 'Turborepo', 'Tailwind CSS'],
     href: 'https://yet.unresolved.xyz/',
     repositoryUrl:
       'https://github.com/dim0627/unresolved.xyz/tree/main/apps/yet',
@@ -44,7 +44,7 @@ export const projects: Project[] = [
     image: '/images/projects/blog-unresolved-xyz.png',
     title: 'blog.unresolved.xyz',
     description: 'Tech blog.',
-    stacks: ['Next.js', 'Vercel', 'Turborepo', 'Tailwind CSS'],
+    stacks: ['Next.js', 'Cloudflare Workers', 'Turborepo', 'Tailwind CSS'],
     href: 'https://blog.unresolved.xyz/',
     repositoryUrl:
       'https://github.com/dim0627/unresolved.xyz/tree/main/apps/blog',


### PR DESCRIPTION
## 背景

Vercel から Cloudflare Workers への移行（#706 / #708）が完了しているにもかかわらず、`apps/blog` と `apps/yet` の README が `create-next-app` 由来のボイラープレートのまま残っており、記載内容が現状と一致していなかった。

| 記載 | 実態 |
| --- | --- |
| `## Deploy on Vercel` | Cloudflare Workers（`wrangler` + `deploy.yml`） |
| `yarn dev` | pnpm |
| `pages/index.js` / `pages/api/hello.js` | App Router 構成で `pages/` 自体が存在しない |
| blog の開発サーバは `localhost:3000` | 実際は `3001`（`next dev --port 3001`） |

## 変更内容

### apps/blog/README.md / apps/yet/README.md

ボイラープレートを破棄し、実際のディレクトリ構成・コマンド・デプロイ経路を説明する内容へ書き直した。それぞれ Getting Started / Content / Build / Deployment の構成とし、`output: 'export'` による静的出力と `pnpm start`（= `wrangler dev`）でのプレビュー方法、`main` への push で `deploy.yml` が走る点を記載している。

### apps/yet/content/projects.ts

`yet.unresolved.xyz` と `blog.unresolved.xyz` の `stacks` が `'Vercel'` のままで、ポートフォリオの記載が事実と異なっていたため `'Cloudflare Workers'` に変更した。

他プロジェクト（taberu.pro / honn.me / r0213.xyz / wasuremono.art）のエントリは本移行の対象外なので変更していない。

### CLAUDE.md

- yet の説明が「static JSON content」となっていたが、実際は `content/` 配下の TypeScript モジュール（`profile.ts` / `projects.ts` / `careers.ts`）なので修正
- CI Pipeline の記述に Security audit が含まれていなかったため追記。あわせて、Next.js が固定する推移的依存の advisory は `pnpm.overrides` で解消する方針（#703 / #710 の前例）を明記
- Deployment の項を新設し、`deploy.yml` と `wrangler.jsonc` による Cloudflare Workers へのデプロイ経路、必要な secrets（`CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` / `SLACK_WEBHOOK_URL`）を記載

## 変更していないもの

調査時に `vercel` への言及として引っかかったが、意図的に残したものを挙げておく。

- **root `README.md` の Remote Caching 節** — Turborepo の Remote Caching はホスティングとは独立した Vercel のサービスであり、この記述は現在も正しい
- **`apps/*/wrangler.jsonc` のコメント** — 「Vercel を向いていた CNAME レコードは事前に削除してある」という移行時の記録であり、内容として正確
- **ブログ記事本文の Vercel 言及** — 執筆時点の事実の記録なので改変しない

## 検証

- `pnpm lint` — 成功（biome 49 ファイル / markdownlint 56 ファイル、いずれも issue なし）

なお `projects.ts` 以外はドキュメントのみの変更で、ビルド成果物には影響しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)