### PR TITLE
yet の Projects の stacks から開発ツーリング系表記を廃止する

### DIFF
--- a/apps/yet/src/content/projects.ts
+++ b/apps/yet/src/content/projects.ts
@@ -5,21 +5,21 @@ export const projects: Project[] = [
     image: '/images/projects/taberu-pro.png',
     title: 'taberu.pro',
     description: 'Fun and casual meal logging app.',
-    stacks: ['TanStack Start', 'Hono', 'Neon', 'Drizzle', 'Clerk', 'Vitest'],
+    stacks: ['TanStack Start', 'Hono', 'Neon', 'Drizzle', 'Clerk'],
     href: 'https://taberu.pro/',
   },
   {
     image: '/images/projects/honn-me.png',
     title: 'honn.me',
     description: 'Book collection maker with dynamic Open Graph image.',
-    stacks: ['TanStack Start', 'NestJS', 'Satori', 'Vitest'],
+    stacks: ['TanStack Start', 'NestJS', 'Satori'],
     href: 'https://honn.me/',
   },
   {
     image: '/images/projects/yet-unresolved-xyz.png',
     title: 'yet.unresolved.xyz',
     description: 'This portfolio site.',
-    stacks: ['Astro', 'Turborepo', 'Tailwind CSS'],
+    stacks: ['Astro', 'Tailwind CSS'],
     href: 'https://yet.unresolved.xyz/',
     repositoryUrl:
       'https://github.com/dim0627/unresolved.xyz/tree/main/apps/yet',
@@ -28,7 +28,7 @@ export const projects: Project[] = [
     image: '/images/projects/blog-unresolved-xyz.png',
     title: 'blog.unresolved.xyz',
     description: 'Tech blog.',
-    stacks: ['Astro', 'Turborepo', 'Tailwind CSS'],
+    stacks: ['Astro', 'Tailwind CSS'],
     href: 'https://blog.unresolved.xyz/',
     repositoryUrl:
       'https://github.com/dim0627/unresolved.xyz/tree/main/apps/blog',
@@ -38,14 +38,14 @@ export const projects: Project[] = [
     title: 'r0213.xyz',
     description:
       'Archive of fictional undelivered documents generated with an LLM.',
-    stacks: ['Astro', 'OpenAI', 'Anthropic', 'Vitest'],
+    stacks: ['Astro', 'OpenAI', 'Anthropic'],
     href: 'https://r0213.xyz/',
   },
   {
     image: '/images/projects/wasuremono-art.png',
     title: 'wasuremono.art',
     description: 'Impossible structures, presented as photographs.',
-    stacks: ['Astro', 'Anthropic', 'Biome'],
+    stacks: ['Astro', 'Anthropic'],
     href: 'https://wasuremono.art/',
   },
   {


### PR DESCRIPTION
## Summary
- Projects の stacks から Linter・テストランナー・モノレポツールの表記を削除しました（Vitest ×3、Biome ×1、Turborepo ×2）
- #716 でホスティング/CDN 系を廃止したのと同じ基準の適用です。開発ツーリングはプロダクトが何で作られているかを説明せず、ツール乗り換えで陳腐化しやすいため、stacks には載せない方針とします

## Test plan
- [x] `pnpm lint` が通ること
- [x] `apps/yet` の `pnpm build`（astro check 込み）が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * プロジェクト一覧に表示される使用技術（技術スタック）を最新の内容に更新しました。
  * 各プロジェクトの実際の構成に合わせて、不要になった技術項目を整理しました。
  * プロジェクトの画像、タイトル、説明、リンクなど、その他の表示情報に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->